### PR TITLE
Disable some uniqueness constraints

### DIFF
--- a/models/Event.js
+++ b/models/Event.js
@@ -16,12 +16,12 @@ const Attendees = new mongoose.Schema({
   removalPassword: {
     type: String,
     trim: true,
-    unique: true,
+    //unique: true, // FIXME: breaks on newer mongodb/mongoose: https://github.com/lowercasename/gathio/issues/75
   },
   id: {
     type: String,
     trim: true,
-    unique: true,
+    //unique: true,
   },
   created: Date,
 })


### PR DESCRIPTION
Works around https://github.com/lowercasename/gathio/issues/75, where only one event is ever able to be created on fresh installs.

This is probably not the right solution, but it is a solution.